### PR TITLE
Update batch files

### DIFF
--- a/windows_setup.bat
+++ b/windows_setup.bat
@@ -3,8 +3,8 @@ pip install astropy
 pip install matplotlib
 pip install photutils
 pip install scikit-image
-pip install astroquery
-pip install pysimplegui
+pip install astroquery==0.4.6
+pip install pysimplegui==4.60.5
 pip install opencv-python
 pip install pandas
 pip install scikit-learn

--- a/windows_update.bat
+++ b/windows_update.bat
@@ -4,8 +4,6 @@ pip install -U astropy
 pip install -U matplotlib
 pip install -U photutils
 pip install -U scikit-image
-pip install -U astroquery
-pip install -U pysimplegui
 pip install -U opencv-python
 pip install -U pandas
 pip install -U scikit-learn


### PR DESCRIPTION
It is better to keep the pysimplegui and astroquery libraries to the older versions. PySimpleGui 5.0 and above requires registration. Astronquery 0.4.7 takes much longer to load because of a messaging test.